### PR TITLE
fix run storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "lint:eslint-fix": "eslint . --fix --ext .js,.ts,.tsx",
     "lint:style": "stylelint 'src/**/*.css'",
     "lint:style-fix": "stylelint --fix 'src/**/*.css'",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
+    "build-storybook": "NODE_OPTIONS=--openssl-legacy-provider build-storybook",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:virtual-update": "vitest run --update",
@@ -71,5 +71,8 @@
     "vite": "3.2.4",
     "vite-plugin-solid": "2.4.0",
     "vitest": "0.25.3"
+  },
+  "dependenciesComments": {
+    "storybook": "maybe need --openssl-legacy-provider until v7 if node18"
   }
 }


### PR DESCRIPTION
In the case of node18, if you use the storybook library that has webpack v4 series as a dependency, a runtime error will occur.
`vite-builder` has an error because webpack v4 exists as a dependency.
Setting `NODE_OPTIONS=--openssl-legacy-provider` solves it.